### PR TITLE
make firefox use marionette

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - BROWSER=firefox BVER=stable
     - BROWSER=firefox BVER=beta
     - BROWSER=firefox BVER=nightly
-    - BROWSER=firefox BVER=esr
 
 matrix:
   fast_finish: true
@@ -20,6 +19,7 @@ matrix:
     - env: BROWSER=chrome  BVER=unstable
     - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
+    - env: BROWSER=firefox BVER=esr
 
 before_install:
   - npm install -g npm@'>=3.0.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- 4.1
+- 6
 
 env:
   matrix:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "chromedriver": "^2.16.0",
-    "selenium-webdriver": "^2.48.0",
+    "geckodriver": "^1.1.3",
+    "selenium-webdriver": "^3.0.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^3.0.0"
   },
@@ -27,7 +28,7 @@
     "grunt-eslint": "^17.2.0",
     "grunt-githooks": "^0.3.1",
     "chromedriver": "^2.16.0",
-    "selenium-webdriver": "^2.52.0",
+    "selenium-webdriver": "^3.0.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^3.0.0",
     "webrtc-adapter": "^2.0.0"

--- a/src/selenium/selenium-lib.js
+++ b/src/selenium/selenium-lib.js
@@ -88,8 +88,12 @@ function buildDriver() {
       .forBrowser(process.env.BROWSER)
       .setFirefoxOptions(firefoxOptions)
       .setChromeOptions(chromeOptions)
-      .setEdgeOptions(edgeOptions)
-      .build();
+      .setEdgeOptions(edgeOptions);
+
+  if (process.env.BROWSER === 'firefox' && getBrowserVersion >= '47') {
+    sharedDriver.getCapabilities().set('marionette', true);
+  }
+  sharedDriver = sharedDriver.build();
 
   // Set global executeAsyncScript() timeout (default is 0) to allow async
   // callbacks to be caught in tests.

--- a/test/testpage.html
+++ b/test/testpage.html
@@ -2,7 +2,7 @@
 <head>
 <meta charset="utf-8">
 <title>Test page for WebRTC utilities</title>
-<script src="../node_modules/webrtc-adapter-test/adapter.js"></script>
+<script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
 </head>
 <body>
 <h1>Test page for WebRTC utilities</h1>


### PR DESCRIPTION
I noticed in https://github.com/webrtc/samples/pull/849 that the tests were not running in Firefox.
This should fix them.

Now if we could stop this, adapters selenium-lib and https://github.com/fippo/testbed/blob/master/webdriver.js from diverging... ;-)