### PR TITLE
selenium: fix getStats

### DIFF
--- a/src/selenium/selenium-lib.js
+++ b/src/selenium/selenium-lib.js
@@ -109,8 +109,14 @@ function getStats(driver, peerConnection) {
   return driver.executeAsyncScript(
       'var callback = arguments[arguments.length - 1];' +
       peerConnection + '.getStats(null).then(function(report) {' +
-      '  callback(report);' +
-      '});');
+      '  callback(report.entries ? [...report.entries()] : report);' +
+      '});')
+    .then(function(entries) {
+      if (Array.isArray(entries)) {
+        return new Map(entries);
+      }
+      return entries;
+    });
 }
 
 module.exports = {

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ test('Check Selenium lib buildDriver method', function(t) {
 
 test('Check Selenium lib getStats method', function(t) {
   if (process.env.BROWSER === 'firefox') {
-    t.skip('getStats not supported on Firefox.');
+    t.skip('getStats test not supported on Firefox.');
     t.end();
     return;
   }
@@ -54,10 +54,10 @@ test('Check Selenium lib getStats method', function(t) {
     }
   })
   .then(function(response) {
-    for (var object in response) {
-      t.ok(object.toString().match('googLibjingleSession_') !== null,
+    response.forEach(function(object) {
+      t.ok(object.type === 'googLibjingleSession',
           'getStats response OK!');
-    }
+    });
     t.end();
   })
   .then(null, function(err) {


### PR DESCRIPTION
this makes getStats use a "custom" serializer instead of plain
JSON.stringify which returns an empty Object for MapLike stats.

Many thanks to @jan-ivar as usual :-)