### PR TITLE
unpin versions, fix bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
     "url": "https://github.com/webrtc/utilities.git"
   },
   "dependencies": {
-    "chromedriver": "2.29.0",
-    "geckodriver": "1.4.0",
-    "selenium-webdriver": "3.3.0",
+    "chromedriver": "^2.33.1",
+    "geckodriver": "^1.9.0",
     "tape": ">=4.0.0",
-    "travis-multirunner": ">=3.0.0"
+    "travis-multirunner": "^4.0.0"
   },
   "bin": {
     "start-tests": "./src/testrunner/start-tests.sh"
@@ -28,9 +27,9 @@
     "grunt-cli": ">=0.1.9",
     "grunt-eslint": "^17.2.0",
     "grunt-githooks": "^0.3.1",
-    "selenium-webdriver": "3.30",
+    "selenium-webdriver": "^3.6.0",
     "tape": ">=4.0.0",
-    "travis-multirunner": ">=3.0.0",
+    "travis-multirunner": "^4.0.0",
     "webrtc-adapter": ">=4.0.0"
   }
 }

--- a/src/selenium/selenium-lib.js
+++ b/src/selenium/selenium-lib.js
@@ -21,25 +21,25 @@ var sharedDriver = null;
 function getBrowserVersion() {
   var browser = process.env.BROWSER;
   var browserChannel = process.env.BVER;
-  var symlink = './browsers/bin/' + browser + '-' + browserChannel + '/';
-  var symPath = fs.readlink(symlink);
 
   // Browser reg expressions and position to look for the milestone version.
-  var chromeExp = '/Chrom(e|ium)\/([0-9]+)\./';
-  var firefoxExp = '/Firefox\/([0-9]+)\./';
-  var chromePos = 2;
-  var firefoxPos = 1;
+  var chromeExp = /\/chrome\/(\d+)\./;
+  var firefoxExp = /\/firefox\/(\d+)\./;
 
-  var browserVersion = function(path, expr, pos) {
-    var match = path.match(expr);
-    return match && match.length >= pos && parseInt(match[pos], 10);
+  var browserVersion = function(expr) {
+    var symlink = './browsers/bin/' + browser + '-' + browserChannel;
+    var pathToBrowser = fs.readlinkSync(symlink);
+    var match = pathToBrowser.match(expr);
+    return match && match.length >= 1 && parseInt(match[1], 10);
   };
 
   switch (browser) {
     case 'chrome':
-      return browserVersion(symPath, chromeExp, chromePos);
+      return browserVersion(chromeExp);
     case 'firefox':
-      return browserVersion(symPath, firefoxExp, firefoxPos);
+      return browserVersion(firefoxExp);
+    case 'safari':
+      return browserChannel;
     default:
       return 'non supported browser.';
   }
@@ -85,7 +85,7 @@ function buildDriver() {
       .setLoggingPrefs(prefs);
 
   // Only enable this for Chrome >= 49.
-  if (process.env.BROWSER === 'chrome' && getBrowserVersion >= '49') {
+  if (process.env.BROWSER === 'chrome' && getBrowserVersion() >= 49) {
     chromeOptions.addArguments('--enable-experimental-web-platform-features');
   }
 
@@ -97,7 +97,7 @@ function buildDriver() {
       .setChromeOptions(chromeOptions)
       .setEdgeOptions(edgeOptions);
 
-  if (process.env.BROWSER === 'firefox' && getBrowserVersion >= '47') {
+  if (process.env.BROWSER === 'firefox' && getBrowserVersion() >= 47) {
     sharedDriver.getCapabilities().set('marionette', true);
   }
   sharedDriver = sharedDriver.build();

--- a/test/start-tests.sh
+++ b/test/start-tests.sh
@@ -13,7 +13,7 @@ export BVER=${BVER-stable}
 BROWSERBIN=$BINDIR/$BROWSER-$BVER
 if [ ! -x $BROWSERBIN ]; then
   echo "Installing browser"
-  ./node_modules/travis-multirunner/setup.sh
+  bash ./node_modules/travis-multirunner/setup.sh
 fi
 echo "Starting browser"
 PATH=$PATH:./node_modules/.bin


### PR DESCRIPTION
attempts to fix https://github.com/webrtc/samples/issues/936

Also uses the fixed version of getBrowserVersion from adapter from before we removed it
and works around the npm 5.something bug that does not set executable permissions